### PR TITLE
Add loose option for semver.satisfies

### DIFF
--- a/README.md
+++ b/README.md
@@ -963,6 +963,15 @@ chai.expect(semver.satisfies('Resin OS 2.0.2 (prod)', '^2.0.0')).to.equal(true);
 chai.expect(semver.satisfies('Resin OS 1.16.0', '^2.0.0')).to.equal(false);
 ```
 
+should correctly evaluate versions with leading zeros.
+
+```js
+chai.expect(semver.satisfies('2019.04.0', '~2019.04.0')).to.equal(true);
+chai.expect(semver.satisfies('2019.04.1', '~2019.04.0')).to.equal(true);
+chai.expect(semver.satisfies('2019.05.0', '~2019.04.0')).to.equal(false);
+chai.expect(semver.satisfies('2020.05.0', '^2019.04.0')).to.equal(false);
+```
+
 should always return false when provided with an invalid semver value.
 
 ```js
@@ -1322,3 +1331,7 @@ chai.expect(semver.inc('Resin OS 2.0.0.rev1 (prod)', 'patch')).to.equal('2.0.1')
 chai.expect(semver.inc('Resin OS 2.0.0+rev4 (dev)', 'patch')).to.equal('2.0.1');
 chai.expect(semver.inc('2.0.6+rev3.dev', 'patch')).to.equal('2.0.7');
 ```
+
+
+
+

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@types/lodash": "^4.1.2 <=4.14.121",
-    "@types/semver": "^5.4.0",
+    "@types/semver": "^6.0.0",
     "lodash": "^4.1.2",
     "semver": "^5.3.0"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -340,7 +340,9 @@ export const satisfies = (version: VersionInput, range: string) => {
 		return false;
 	}
 
-	return semver.satisfies(version, range);
+	return semver.satisfies(version, range, {
+		loose: true,
+	});
 };
 
 /**

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -714,6 +714,13 @@ describe('balena-semver', () => {
 			expect(semver.satisfies('Resin OS 1.16.0', '^2.0.0')).to.equal(false);
 		});
 
+		it('should correctly evaluate versions with leading zeros', () => {
+			expect(semver.satisfies('2019.04.0', '~2019.04.0')).to.equal(true);
+			expect(semver.satisfies('2019.04.1', '~2019.04.0')).to.equal(true);
+			expect(semver.satisfies('2019.05.0', '~2019.04.0')).to.equal(false);
+			expect(semver.satisfies('2020.05.0', '^2019.04.0')).to.equal(false);
+		});
+
 		it('should always return false when provided with an invalid semver value', () => {
 			expect(semver.satisfies('Linux 14.04', '^2.0.0')).to.equal(false);
 			expect(semver.satisfies('A development version', '^2.0.0')).to.equal(


### PR DESCRIPTION
This gives the range parser more freedom when interpreting the range, in
particular it allows to pass ranges that contain leading 0s

Change-type: minor
Signed-off-by: Giovanni Garufi <giovanni@balena.io>