### PR TITLE
Support underscore version variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,15 @@ chai.expect(semver.compare('Resin OS 2.0.0+rev3', 'Resin OS 2.0.0+rev3.prod')).t
 chai.expect(semver.compare('Resin OS 2.0.0+rev3 (dev)', 'Resin OS 2.0.0+rev3+prod')).to.equal(1); // B is invalid
 ```
 
+should correctly compare versions with underscores.
+
+```js
+chai.expect(semver.compare('6.0.1_logstream', '5.0.1')).to.equal(1);
+chai.expect(semver.compare('6.0.1_logstream', '5.0.1_logstream')).to.equal(1);
+chai.expect(semver.compare('6.0.1_logstream', '7.0.1')).to.equal(-1);
+chai.expect(semver.compare('6.0.1_logstream', '6.0.1')).to.equal(1);
+```
+
 <a name="balena-semver-rcompare"></a>
 
 <a name="rcompare"></a>
@@ -448,6 +457,12 @@ chai.expect(semver.major('Linux 14.04')).to.equal(null);
 chai.expect(semver.major('Software version 42.3.20170726.72bbcf8')).to.equal(null);
 ```
 
+should correctly match underscored versions.
+
+```js
+chai.expect(semver.major('7.1.2_logstream')).to.equal(7);
+```
+
 <a name="balena-semver-prerelease"></a>
 
 <a name="prerelease"></a>
@@ -612,6 +627,13 @@ chai.expect(semver.gte('Resin OS 2.0.0+rev3.dev', 'Resin OS 2.0.0+rev3.dev')).to
 chai.expect(semver.gte('2.0.0', 'Resin OS 2.0.0.dev')).to.equal(true);
 chai.expect(semver.gte('Resin OS 2.0.0.dev', '2.0.0')).to.equal(false);
 chai.expect(semver.gte('Resin OS 2.0.0.dev', '2.0.0.dev')).to.equal(true);
+```
+
+should correctly compare underscored versions.
+
+```js
+chai.expect(semver.gte('7.0.1_logstream', '7.0.1')).to.equal(true);
+chai.expect(semver.gte('7.0.1_logstream', '7.0.1_logstream')).to.equal(true);
 ```
 
 <a name="balena-semver-gt"></a>
@@ -1165,6 +1187,25 @@ should correctly parse undefined values.
 
 ```js
 chai.expect(semver.parse(undefined)).to.equal(null);
+```
+
+should correctly parse versions with underscores.
+
+```js
+chai.expect(semver.parse('6.0.1_logstream')).to.deep.include({
+    raw: '6.0.1_logstream',
+    major: 6,
+    minor: 0,
+    patch: 1,
+    version: '6.0.1',
+    build: ['logstream'],
+});
+```
+
+should not parse versions with multiple underscores.
+
+```js
+chai.expect(semver.parse('7.0.1_logstream_test')).to.be.null;
 ```
 
 <a name="balena-semver-valid"></a>

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,9 @@ const safeSemver = (version: string) => {
 	// fix major.minor.patch.rev to use rev as build metadata
 	return (
 		version
+			// Replace any underscores with plusses, as they should
+			// have the same semantics
+			.replace(/([0-9]+\.[0-9]+\.[0-9]+)_(\w+)/, '$1+$2')
 			.replace(/(\.[0-9]+)\.rev/, '$1+rev')
 			// fix major.minor.patch.prod to be treat .dev & .prod as build metadata
 			.replace(/([0-9]+\.[0-9]+\.[0-9]+)\.(dev|prod)\b/i, '$1+$2')

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -208,6 +208,13 @@ describe('balena-semver', () => {
 				semver.compare('Resin OS 2.0.0+rev3 (dev)', 'Resin OS 2.0.0+rev3+prod'),
 			).to.equal(1); // B is invalid
 		});
+
+		it('should correctly compare versions with underscores', () => {
+			expect(semver.compare('6.0.1_logstream', '5.0.1')).to.equal(1);
+			expect(semver.compare('6.0.1_logstream', '5.0.1_logstream')).to.equal(1);
+			expect(semver.compare('6.0.1_logstream', '7.0.1')).to.equal(-1);
+			expect(semver.compare('6.0.1_logstream', '6.0.1')).to.equal(1);
+		});
 	});
 
 	describe('.rcompare()', () => {
@@ -332,6 +339,10 @@ describe('balena-semver', () => {
 				null,
 			);
 		});
+
+		it('should correctly match underscored versions', () => {
+			expect(semver.major('7.1.2_logstream')).to.equal(7);
+		});
 	});
 
 	describe('.prerelease()', () => {
@@ -448,6 +459,11 @@ describe('balena-semver', () => {
 			expect(semver.gte('2.0.0', 'Resin OS 2.0.0.dev')).to.equal(true);
 			expect(semver.gte('Resin OS 2.0.0.dev', '2.0.0')).to.equal(false);
 			expect(semver.gte('Resin OS 2.0.0.dev', '2.0.0.dev')).to.equal(true);
+		});
+
+		it('should correctly compare underscored versions', () => {
+			expect(semver.gte('7.0.1_logstream', '7.0.1')).to.equal(true);
+			expect(semver.gte('7.0.1_logstream', '7.0.1_logstream')).to.equal(true);
 		});
 	});
 
@@ -882,6 +898,21 @@ describe('balena-semver', () => {
 
 		it('should correctly parse undefined values', () => {
 			expect(semver.parse(undefined)).to.equal(null);
+		});
+
+		it('should correctly parse versions with underscores', () => {
+			expect(semver.parse('6.0.1_logstream')).to.deep.include({
+				raw: '6.0.1_logstream',
+				major: 6,
+				minor: 0,
+				patch: 1,
+				version: '6.0.1',
+				build: ['logstream'],
+			});
+		});
+
+		it('should not parse versions with multiple underscores', () => {
+			expect(semver.parse('7.0.1_logstream_test')).to.be.null;
 		});
 	});
 


### PR DESCRIPTION
A bunch of supervisor versions container the string `_logstream` at the
end. We convert this to a +logstream and handle it like any other build
metadata.

Change-type: minor
Signed-off-by: Cameron Diver <cameron@balena.io>